### PR TITLE
Add Python 3.13 to CI and supported Python versions

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -51,7 +51,7 @@ jobs:
             antsibull_fileutils_ref: main
           - name: Ansible 11
             options: '-e antsibull_ansible_version=11.99.0'
-            python: '3.12'
+            python: '3.13'
             antsibull_changelog_ref: main
             antsibull_core_ref: main
             antsibull_docs_parser_ref: main

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -30,12 +30,12 @@ jobs:
       matrix:
         include:
           - session: test
-            python-versions: "3.9, 3.10, 3.11, 3.12"
+            python-versions: "3.9, 3.10, 3.11, 3.12, 3.13"
             codecov: true
             packages: ""
 
           - session: "check_package_files(8.1.0)"
-            python-versions: "3.11"
+            python-versions: "3.12"
             codecov: true
             packages: ""
 
@@ -45,12 +45,12 @@ jobs:
             packages: ""
 
           - session: "check_package_files(8.1.0_setup_cfg)"
-            python-versions: "3.11"
+            python-versions: "3.13"
             codecov: true
             packages: ""
 
           - session: lint
-            python-versions: "3.11"
+            python-versions: "3.13"
             codecov: false
             packages: ""
     name: "Run nox ${{ matrix.session }} session"

--- a/changelogs/fragments/python-3.13.yml
+++ b/changelogs/fragments/python-3.13.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Declare support for Python 3.13 (https://github.com/ansible-community/antsibull-build/pull/637).

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,7 +76,7 @@ def other_antsibull(
     return to_install
 
 
-@nox.session(python=["3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session: nox.Session):
     install(
         session,
@@ -86,7 +86,7 @@ def test(session: nox.Session):
     )
     covfile = Path(session.create_tmp(), ".coverage")
     more_args = []
-    if session.python in {"3.11", "3.12"}:
+    if session.python in {"3.11", "3.12", "3.13"}:
         more_args.append("--error-for-skips")
     session.run(
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
Since Python 3.13.0 has been released, let's use it in CI and officially support it.