### PR TITLE
Make new-ansible no longer remove remove_collection_changelog_entries from changelog.yaml files

### DIFF
--- a/changelogs/fragments/641-changelog-fix.yml
+++ b/changelogs/fragments/641-changelog-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix ``new-ansible`` subcommand so it will not wipe the newly added extra data from ``changelog.yaml`` files (https://github.com/ansible-community/antsibull-build/pull/641)."

--- a/src/antsibull_build/new_ansible.py
+++ b/src/antsibull_build/new_ansible.py
@@ -67,6 +67,6 @@ def new_ansible_command() -> int:
     )
 
     changelog = ChangelogData.ansible(app_ctx.extra["dest_data_dir"])
-    changelog.changes.save()
+    changelog.save()
 
     return 0


### PR DESCRIPTION
Noticed this during the Ansible 11.0.0b1 release. We'll have to redo that release once this is merged and a bugfix release of antsibull-build is out.