### PR TITLE
Fix links to manual changelogs

### DIFF
--- a/changelogs/fragments/642-changelog-link.yml
+++ b/changelogs/fragments/642-changelog-link.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix link to changelogs for collections without ``changelog.yaml`` (https://github.com/ansible-community/antsibull-build/pull/642)."

--- a/src/antsibull_build/build_changelog.py
+++ b/src/antsibull_build/build_changelog.py
@@ -177,9 +177,9 @@ def render_md_table(headings: list[str], cells: list[list[str]]) -> str:
 
 def format_link(title: str, url: str, text_format: TextFormat) -> str:
     if text_format == TextFormat.RESTRUCTURED_TEXT:
-        return f"`{title} <{url}>`_"
+        return f"`{title} <{url}>`__"
     if text_format == TextFormat.MARKDOWN:
-        return f"`[{title}]({url})"
+        return f"[{title}]({url})"
     raise ValueError(f"Unknown format {format}")
 
 


### PR DESCRIPTION
Result: https://github.com/ansible-community/ansible-build-data/pull/494