### PR TITLE
Ansible porting guide: use tagged releases to pull core porting guides

### DIFF
--- a/changelogs/fragments/544-porting_guide_tagged.yaml
+++ b/changelogs/fragments/544-porting_guide_tagged.yaml
@@ -2,4 +2,4 @@
 minor_changes:
   - Use tagged ansible-core / ansible-documentation releases to retrieve core
     porting guide
-    (https://github.com/ansible-community/antsibull/pull/544).
+    (https://github.com/ansible-community/antsibull/pull/646).

--- a/changelogs/fragments/544-porting_guide_tagged.yaml
+++ b/changelogs/fragments/544-porting_guide_tagged.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Use tagged ansible-core / ansible-documentation releases to retrieve core
+    porting guide
+    (https://github.com/ansible-community/antsibull/pull/544).

--- a/src/antsibull_build/changelog.py
+++ b/src/antsibull_build/changelog.py
@@ -53,6 +53,8 @@ from antsibull_fileutils.yaml import load_yaml_bytes
 from packaging.version import Version as PypiVer
 from semantic_version import Version as SemVer
 
+from antsibull_build.utils.urls import get_documentation_repo_raw_url
+
 mlog = log.fields(mod=__name__)
 
 
@@ -247,8 +249,14 @@ def read_changelog_file(tarball_path: str, is_ansible_core=False) -> bytes | Non
     return read_file(tarball_path, matcher)
 
 
-def get_porting_guide_filename(version: PypiVer):
-    return f"docs/docsite/rst/porting_guides/porting_guide_core_{version.major}.{version.minor}.rst"
+def get_core_porting_guide_url(version: PypiVer):
+    major_minor = f"{version.major}.{version.minor}"
+    return (
+        get_documentation_repo_raw_url(version)
+        + f"/v{version}"
+        + "/docs/docsite/rst/porting_guides"
+        + f"/porting_guide_core_{major_minor}.rst"
+    )
 
 
 class CollectionChangelogCollector:
@@ -409,11 +417,7 @@ class AnsibleCoreChangelogCollector:
         self.changelog = ChangelogData.concatenate(changelogs)
 
     async def download_porting_guide(self, aio_session: aiohttp.client.ClientSession):
-        branch_url = (
-            "https://raw.githubusercontent.com/ansible/ansible-documentation/devel"
-        )
-
-        query_url = f"{branch_url}/{get_porting_guide_filename(self.latest)}"
+        query_url = get_core_porting_guide_url(self.latest)
         async with aio_session.get(query_url) as response:
             self.porting_guide = await response.read()
 

--- a/src/antsibull_build/constants.py
+++ b/src/antsibull_build/constants.py
@@ -26,6 +26,16 @@ ANSIBLE_FORUM_URL = "https://forum.ansible.com"
 
 COLLECTION_EXCLUDE_DIRS = ("docs", "tests")
 
+# First ansible-core version that has its documentation split out into
+# ansible/ansible-documentation.
+ANSIBLE_DOCUMENTATION_MINIMUM = PypiVer("2.15.2")
+ANSIBLE_DOCUMENTATION_RANGES: dict[str, PypiVer] = {
+    "2.13": PypiVer("2.13.11"),
+    "2.14": PypiVer("2.14.8"),
+}
+ANSIBLE_DOCUMENTATION_RAW_URL = "https://github.com/ansible/ansible-documentation/raw"
+ANSIBLE_CORE_RAW_URL = "https://github.com/ansible/ansible/raw"
+
 SANITY_TESTS_DEFAULT: tuple[str, ...] = (
     "ansible-doc",
     "compile",

--- a/src/antsibull_build/utils/urls.py
+++ b/src/antsibull_build/utils/urls.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2023 Maxwell G <maxwell@gtmx.me>
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Utilities for working with ansible URLs
+"""
+
+from __future__ import annotations
+
+from packaging.version import Version as PypiVer
+
+from ..constants import (
+    ANSIBLE_CORE_RAW_URL,
+    ANSIBLE_DOCUMENTATION_MINIMUM,
+    ANSIBLE_DOCUMENTATION_RANGES,
+    ANSIBLE_DOCUMENTATION_RAW_URL,
+)
+
+
+def get_documentation_repo_raw_url(version: PypiVer) -> str:
+    """
+    Return the raw url for retrieving ansible documentation files
+    See https://github.com/ansible-community/community-topics/issues/240.
+    """
+    major_minor = f"{version.major}.{version.minor}"
+    minimum_version = ANSIBLE_DOCUMENTATION_RANGES.get(
+        major_minor, ANSIBLE_DOCUMENTATION_MINIMUM
+    )
+    return (
+        ANSIBLE_DOCUMENTATION_RAW_URL
+        if version >= minimum_version
+        else ANSIBLE_CORE_RAW_URL
+    )

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2023 Maxwell G <maxwell@gtmx.me>
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# It doesn't make sense to split up the long URLs
+# flake8: noqa E501
+
+import pytest
+from packaging.version import Version as PypiVer
+
+from antsibull_build.changelog import get_core_porting_guide_url
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        pytest.param(
+            PypiVer("2.12.0"),
+            "https://github.com/ansible/ansible/raw/v2.12.0/docs/docsite/rst/porting_guides/porting_guide_core_2.12.rst",
+        ),
+        pytest.param(
+            PypiVer("2.13.0"),
+            "https://github.com/ansible/ansible/raw/v2.13.0/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst",
+        ),
+        pytest.param(
+            PypiVer("2.13.11"),
+            "https://github.com/ansible/ansible-documentation/raw/v2.13.11/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst",
+        ),
+        pytest.param(
+            PypiVer("2.14.8"),
+            "https://github.com/ansible/ansible-documentation/raw/v2.14.8/docs/docsite/rst/porting_guides/porting_guide_core_2.14.rst",
+        ),
+        pytest.param(
+            PypiVer("2.16.0a1"),
+            "https://github.com/ansible/ansible-documentation/raw/v2.16.0a1/docs/docsite/rst/porting_guides/porting_guide_core_2.16.rst",
+        ),
+    ],
+)
+def test_get_core_porting_guide_url(version: PypiVer, expected: str):
+    assert get_core_porting_guide_url(version) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2023 Maxwell G <maxwell@gtmx.me>
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+from packaging.version import Version as PypiVer
+
+from antsibull_build.constants import (
+    ANSIBLE_CORE_RAW_URL,
+    ANSIBLE_DOCUMENTATION_RAW_URL,
+)
+from antsibull_build.utils.urls import get_documentation_repo_raw_url
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        pytest.param(PypiVer("2.12.0"), ANSIBLE_CORE_RAW_URL),
+        pytest.param(PypiVer("2.13.0"), ANSIBLE_CORE_RAW_URL),
+        pytest.param(PypiVer("2.13.11"), ANSIBLE_DOCUMENTATION_RAW_URL),
+        pytest.param(PypiVer("2.14.8"), ANSIBLE_DOCUMENTATION_RAW_URL),
+        pytest.param(PypiVer("2.16.0a1"), ANSIBLE_DOCUMENTATION_RAW_URL),
+    ],
+)
+def test_get_documentation_repo_raw_url(version: PypiVer, expected: str):
+    assert get_documentation_repo_raw_url(version) == expected


### PR DESCRIPTION
This is a rebased version of #544.

Closes #544.