### PR TITLE
Changelog/porting guide: add a note that removed collections can still be installed manually

### DIFF
--- a/changelogs/fragments/647-removal-hint.yml
+++ b/changelogs/fragments/647-removal-hint.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - "When announcing collection removals and upcoming removals in the changelog, add a note that that can still be installed manually
+  - "When announcing collection removals and upcoming removals in the changelog, add a note that users can still manually install removed collections
      (https://github.com/ansible-community/antsibull-build/pull/647)."

--- a/changelogs/fragments/647-removal-hint.yml
+++ b/changelogs/fragments/647-removal-hint.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "When announcing collection removals and upcoming removals in the changelog, add a note that that can still be installed manually
+     (https://github.com/ansible-community/antsibull-build/pull/647)."

--- a/src/antsibull_build/build_changelog.py
+++ b/src/antsibull_build/build_changelog.py
@@ -492,6 +492,12 @@ def append_removed_collections(
                 f"(previously included version: {collection_version})",
                 text_format=TextFormat.RESTRUCTURED_TEXT,
             )
+        section.ensure_paragraph_break()
+        section.add_text(
+            "You can still install a removed collection manually with"
+            " ``ansible-galaxy collection install <name-of-collection>``.",
+            text_format=TextFormat.RESTRUCTURED_TEXT,
+        )
         section.close()
 
 
@@ -702,6 +708,12 @@ def append_porting_guide(
                 f"(previously included version: {collection_version})",
                 text_format=TextFormat.RESTRUCTURED_TEXT,
             )
+        section.ensure_paragraph_break()
+        section.add_text(
+            "You can still install a removed collection manually with"
+            " ``ansible-galaxy collection install <name-of-collection>``.",
+            text_format=TextFormat.RESTRUCTURED_TEXT,
+        )
         section.close()
 
     for section_name in ["removed_features", "deprecated_features"]:

--- a/src/antsibull_build/changelog.py
+++ b/src/antsibull_build/changelog.py
@@ -717,6 +717,12 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
                 "community_steering_committee.html#creating-community-topic>`__."
             )
 
+    if sentences and reason not in ("renamed", "deprecated"):
+        sentences.append(
+            "After removal, users can still install this collection with "
+            f"``ansible-galaxy collection install {collection}``."
+        )
+
     if not sentences:
         return None
     return _create_fragment("deprecated_features", sentences), str(announce_version)


### PR DESCRIPTION
This is not obvious to users (see for example https://forum.ansible.com/t/8609/7), so let's be more explicitly in the changelog and porting guide.

You can see the results in https://github.com/ansible-community/ansible-build-data/pull/514.