### PR TITLE
Fix bug in PyPI URL info data structure, remove unnecessary workaround for pydantic 1.x

### DIFF
--- a/changelogs/fragments/648-fix.yml
+++ b/changelogs/fragments/648-fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "Fix PyPI URL info data structure (https://github.com/ansible-community/antsibull-build/pull/648)."
+minor_changes:
+  - "Remove more backwards compatibility code for pydantic 1.x (https://github.com/ansible-community/antsibull-build/pull/648)."

--- a/src/antsibull_build/cli/antsibull_build.py
+++ b/src/antsibull_build/cli/antsibull_build.py
@@ -872,8 +872,6 @@ def run(args: list[str]) -> int:
 
     context_data = app_context.create_contexts(args=parsed_args, cfg=cfg)
     with app_context.app_and_lib_context(context_data) as (app_ctx, dummy_):
-        # TODO: Call `model_dump()` instead of deprecated `dict()`
-        # once support for pydantic v1/antsibull-core v2 is dropped
         twiggy.dict_config(app_ctx.logging_cfg.model_dump())
         flog.debug("Set logging config")
 

--- a/src/antsibull_build/pypi.py
+++ b/src/antsibull_build/pypi.py
@@ -86,7 +86,6 @@ class ReleaseInfo(p.BaseModel):
 
 
 class UrlInfo(p.BaseModel):
-    comment_text: str
     digests: dict[str, str]
     filename: str
     md5_digest: str
@@ -113,9 +112,7 @@ class UrlInfo(p.BaseModel):
         return await verify_hash(file, self.sha256sum, chunksize=lib_ctx.chunksize)
 
 
-# TODO pydantic v2+:
-# + Release.model_rebuild
-getattr(Release, "model_rebuild", getattr(Release, "update_forward_refs"))()
+Release.model_rebuild()
 
 
 class PyPIClient:

--- a/tests/test_data/announce-7.0.0/announcements.json
+++ b/tests/test_data/announce-7.0.0/announcements.json
@@ -6,7 +6,6 @@
     "core_major_version": "2.14",
     "build_data_path": "https://github.com/ansible-community/ansible-build-data/blob/7.0.0/7",
     "release_tarball": {
-      "comment_text": "",
       "digests": {
         "blake2b_256": "18fd963a3328d6f72e54d17dfbb40af6e9d6827333a5f1745c79c6d81b30dc85",
         "md5": "4250dd7c6b1f35f2a1f6039b2c83f85a",
@@ -24,7 +23,6 @@
       "yanked_reason": null
     },
     "release_wheel": {
-      "comment_text": "",
       "digests": {
         "blake2b_256": "f7624b3ee9140dd95b49ae43a0321e2a517fd6101797e620bbed7095a3ecd46e",
         "md5": "c368c52d3f785792042e37accd704cd4",

--- a/tests/test_data/announce-7.0.0b1/announcements.json
+++ b/tests/test_data/announce-7.0.0b1/announcements.json
@@ -6,7 +6,6 @@
     "core_major_version": "2.14",
     "build_data_path": "https://github.com/ansible-community/ansible-build-data/blob/7.0.0b1/7",
     "release_tarball": {
-      "comment_text": "",
       "digests": {
         "blake2b_256": "0bb3198b439cd7360c74bd91767e995e588ab0c4a65c17cd7bba340c3b0995b1",
         "md5": "96c7dba562d369a766a71171705bd4ec",
@@ -24,7 +23,6 @@
       "yanked_reason": null
     },
     "release_wheel": {
-      "comment_text": "",
       "digests": {
         "blake2b_256": "bc85ade95555a7602c3a8d813d718ece7e91d61599f31d72ceda9c12b19a43a8",
         "md5": "2be31cd9b9712437198766838ed14f36",

--- a/tests/test_data/announce-7.4.0/announcements.json
+++ b/tests/test_data/announce-7.4.0/announcements.json
@@ -6,7 +6,6 @@
     "core_major_version": "2.14",
     "build_data_path": "https://github.com/ansible-community/ansible-build-data/blob/7.4.0/7",
     "release_tarball": {
-      "comment_text": "",
       "digests": {
         "blake2b_256": "454b2087a0fe8265828df067e57d7d156426cdc8f7cd94ad3178c6510d81e2c0",
         "md5": "cd3b99ebb7d9c0f6f2e94887aa35fd52",
@@ -24,7 +23,6 @@
       "yanked_reason": null
     },
     "release_wheel": {
-      "comment_text": "",
       "digests": {
         "blake2b_256": "0d341b50f134f3136eeddf87f1b50253c1dece059407f5de57044963c82d07c0",
         "md5": "672a34876e3619156f94eadcb8d55b83",


### PR DESCRIPTION
I wasn't able to generate the announcements for Ansible 11.2.0 with the current version, apparently some PyPI data structure changed.

While fixing that I found and removed some pydantic 1.x backwards compatibility code that I removed.