### PR TITLE
Fix outdated link on PyPI

### DIFF
--- a/src/antsibull_build/data/ansible-readme.rst
+++ b/src/antsibull_build/data/ansible-readme.rst
@@ -73,8 +73,9 @@ Get Involved
 *  Read `Community Information <https://docs.ansible.com/ansible/latest/community>`_ for ways to contribute to 
    and interact with the project, including forum information and how
    to submit bug reports and code to Ansible or Ansible collections.
-*  Join a `Working Group <https://github.com/ansible/community/wiki>`_, an organized community
-   devoted to a specific technology domain or platform.
+*  Join `Forum Groups <https://forum.ansible.com/g>`_ you are interested in,
+   which are groups of users that are involved in specific topics, like a
+   technology domain or platform.
 *  Talk to us before making larger changes
    to avoid duplicate efforts. This not only helps everyone
    know what is going on, but it also helps save time and effort if we decide

--- a/tests/test_data/package-files/7.5.0/README.rst
+++ b/tests/test_data/package-files/7.5.0/README.rst
@@ -73,8 +73,9 @@ Get Involved
 *  Read `Community Information <https://docs.ansible.com/ansible/latest/community>`_ for ways to contribute to 
    and interact with the project, including forum information and how
    to submit bug reports and code to Ansible or Ansible collections.
-*  Join a `Working Group <https://github.com/ansible/community/wiki>`_, an organized community
-   devoted to a specific technology domain or platform.
+*  Join `Forum Groups <https://forum.ansible.com/g>`_ you are interested in,
+   which are groups of users that are involved in specific topics, like a
+   technology domain or platform.
 *  Talk to us before making larger changes
    to avoid duplicate efforts. This not only helps everyone
    know what is going on, but it also helps save time and effort if we decide

--- a/tests/test_data/package-files/8.1.0/README.rst
+++ b/tests/test_data/package-files/8.1.0/README.rst
@@ -73,8 +73,9 @@ Get Involved
 *  Read `Community Information <https://docs.ansible.com/ansible/latest/community>`_ for ways to contribute to 
    and interact with the project, including forum information and how
    to submit bug reports and code to Ansible or Ansible collections.
-*  Join a `Working Group <https://github.com/ansible/community/wiki>`_, an organized community
-   devoted to a specific technology domain or platform.
+*  Join `Forum Groups <https://forum.ansible.com/g>`_ you are interested in,
+   which are groups of users that are involved in specific topics, like a
+   technology domain or platform.
 *  Talk to us before making larger changes
    to avoid duplicate efforts. This not only helps everyone
    know what is going on, but it also helps save time and effort if we decide

--- a/tests/test_data/package-files/force_setup_cfg/8.1.0/README.rst
+++ b/tests/test_data/package-files/force_setup_cfg/8.1.0/README.rst
@@ -73,8 +73,9 @@ Get Involved
 *  Read `Community Information <https://docs.ansible.com/ansible/latest/community>`_ for ways to contribute to 
    and interact with the project, including forum information and how
    to submit bug reports and code to Ansible or Ansible collections.
-*  Join a `Working Group <https://github.com/ansible/community/wiki>`_, an organized community
-   devoted to a specific technology domain or platform.
+*  Join `Forum Groups <https://forum.ansible.com/g>`_ you are interested in,
+   which are groups of users that are involved in specific topics, like a
+   technology domain or platform.
 *  Talk to us before making larger changes
    to avoid duplicate efforts. This not only helps everyone
    know what is going on, but it also helps save time and effort if we decide


### PR DESCRIPTION
The [ansible package on PyPI](https://pypi.org/project/ansible/11.2.0/) still has a link to the (Archived) Ansible Community Wiki.

https://forum.ansible.com/t/40061