### PR TITLE
utils get_pkg_data: use importlib.resources

### DIFF
--- a/changelogs/fragments/655-importlib.yaml
+++ b/changelogs/fragments/655-importlib.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - internal - switch from ``pkgutil`` to ``importlib.resources`` for loading
+    package data files
+    (https://github.com/ansible-community/antsibull-build/pull/655).

--- a/src/antsibull_build/utils/get_pkg_data.py
+++ b/src/antsibull_build/utils/get_pkg_data.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-import pkgutil
+from importlib import resources
 
 
 def get_antsibull_data(filename: str) -> bytes:
@@ -18,9 +18,10 @@ def get_antsibull_data(filename: str) -> bytes:
     The filename can be a relative path separated with '/' to access subdirectories.
     See https://docs.python.org/3/library/pkgutil.html#pkgutil.get_data for details.
     """
-    data = pkgutil.get_data("antsibull_build.data", filename)
-    if data is None:
+
+    try:
+        return resources.files("antsibull_build.data").joinpath(filename).read_bytes()
+    except (ImportError, OSError) as exc:
         raise RuntimeError(
             f"Cannot find {filename} in the antsibull_build.data package"
-        )
-    return data
+        ) from exc


### PR DESCRIPTION
importlib.resources is now the preferred way to load package data. The files API is available in the stdlib since Python 3.9.