### PR TITLE
python_metadata: remove License:: classifiers from Ansible 12+

### DIFF
--- a/changelogs/fragments/658-bye-bye-license-classifier.yaml
+++ b/changelogs/fragments/658-bye-bye-license-classifier.yaml
@@ -1,0 +1,6 @@
+---
+removed_features:
+  - python_metadata - remove deprecated ``License::`` classifiers from package
+    metadata to avoid setuptools ``DeprecationWarning``
+   (https://github.com/ansible-community/antsibull-build/issues/651,
+   https://github.com/ansible-community/antsibull-build/pull/658).

--- a/changelogs/fragments/658-bye-bye-license-classifier.yaml
+++ b/changelogs/fragments/658-bye-bye-license-classifier.yaml
@@ -1,6 +1,6 @@
 ---
 removed_features:
-  - python_metadata - remove deprecated ``License::`` classifiers from package
+  - python_metadata - remove deprecated ``License::`` classifiers from Ansible 12+ package
     metadata to avoid setuptools ``DeprecationWarning``
    (https://github.com/ansible-community/antsibull-build/issues/651,
    https://github.com/ansible-community/antsibull-build/pull/658).

--- a/src/antsibull_build/constants.py
+++ b/src/antsibull_build/constants.py
@@ -17,6 +17,7 @@ MINIMUM_ANSIBLE_VERSIONS = {
     # Whether to store setuptools config in setup.cfg
     "BUILD_META_MAKER": PypiVer("9.0.0.dev0"),
     "BUILD_META_NEW_URLS": PypiVer("9.0.0rc1"),
+    "REMOVED_LICENSE_CLASSIFIERS": PypiVer("12.0.0.dev0"),
 }
 
 DOCSITE_BASE_URL = "https://docs.ansible.com/ansible"

--- a/src/antsibull_build/python_metadata.py
+++ b/src/antsibull_build/python_metadata.py
@@ -86,6 +86,10 @@ NEW_URLS = IniDict(
     }
 )
 
+LICENSE_CLASSIFIER = (
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
+)
+
 DEFAULT_METADATA: dict[str, INI_TYPES] = {
     "name": "ansible",
     "description": "Radically simple IT automation",
@@ -279,6 +283,11 @@ class BuildMetaMaker:
         self["metadata"].setdefault("classifiers", IniList()).extend(
             self.core_python_classifiers
         )
+        if (
+            self.ansible_version
+            < MINIMUM_ANSIBLE_VERSIONS["REMOVED_LICENSE_CLASSIFIERS"]
+        ):
+            self["metadata"]["classifiers"].append(LICENSE_CLASSIFIER)
         self["metadata"].setdefault(
             "project_urls",
             (

--- a/src/antsibull_build/python_metadata.py
+++ b/src/antsibull_build/python_metadata.py
@@ -103,7 +103,6 @@ DEFAULT_METADATA: dict[str, INI_TYPES] = {
             "Intended Audience :: Developers",
             "Intended Audience :: Information Technology",
             "Intended Audience :: System Administrators",
-            "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
             "Natural Language :: English",
             "Operating System :: POSIX",
         ]

--- a/tests/test_data/package-files/force_setup_cfg/8.1.0/setup.cfg
+++ b/tests/test_data/package-files/force_setup_cfg/8.1.0/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
 	  Programming Language :: Python :: 3.10
 	  Programming Language :: Python :: 3.11
 	  Programming Language :: Python :: 3 :: Only
+	  License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
 version = 8.1.0
 project_urls = 
 	Build Data = https://github.com/ansible-community/ansible-build-data

--- a/tests/test_data/package-files/force_setup_cfg/8.1.0/setup.cfg
+++ b/tests/test_data/package-files/force_setup_cfg/8.1.0/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
 	  Intended Audience :: Developers
 	  Intended Audience :: Information Technology
 	  Intended Audience :: System Administrators
-	  License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
 	  Natural Language :: English
 	  Operating System :: POSIX
 	  Programming Language :: Python :: 3


### PR DESCRIPTION
`License::` classifiers have been deprecated in favor of the new PEP 639 `license` field that accepts an SPDX expression in pyproject.toml. setuptools now prints a large deprecation warning when using the `License::` classifiers. We can't adopt the new standard, as we don't store configuration in pyproject.toml and do not maintain a cumulative SPDX license expression that encompasses the additional GPL-compatible licenses present in some collections. For now, let's just remove classifier. We still provide a COPYING file for ansible as a whole and preserve individual collection's license and copyright statements.

```
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()

```

Fixes: https://github.com/ansible-community/antsibull-build/issues/651