### PR TITLE
Use devel porting guide for 2.19.0a1

### DIFF
--- a/changelogs/fragments/660-12.0.0a1-use-devel-changelog.yaml
+++ b/changelogs/fragments/660-12.0.0a1-use-devel-changelog.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Use devel changelog for 2.19.0a1 so
+    https://github.com/ansible/ansible-documentation/pull/2429 gets included
+    (https://github.com/ansible-community/antsibull-build/pull/660).

--- a/changelogs/fragments/660-12.0.0a1-use-devel-changelog.yaml
+++ b/changelogs/fragments/660-12.0.0a1-use-devel-changelog.yaml
@@ -1,5 +1,5 @@
 ---
 minor_changes:
-  - Use devel changelog for 2.19.0a1 so
+  - Use devel porting guide for 2.19.0a1 so
     https://github.com/ansible/ansible-documentation/pull/2429 gets included
     (https://github.com/ansible-community/antsibull-build/pull/660).

--- a/src/antsibull_build/constants.py
+++ b/src/antsibull_build/constants.py
@@ -33,6 +33,10 @@ ANSIBLE_DOCUMENTATION_MINIMUM = PypiVer("2.15.2")
 ANSIBLE_DOCUMENTATION_RANGES: dict[str, PypiVer] = {
     "2.13": PypiVer("2.13.11"),
     "2.14": PypiVer("2.14.8"),
+    # Temporarily use devel changelog for 2.19.0a1
+    # so https://github.com/ansible/ansible-documentation/pull/2429
+    # gets included.
+    "2.19": PypiVer("2.19.0a2"),
 }
 ANSIBLE_DOCUMENTATION_RAW_URL = "https://github.com/ansible/ansible-documentation/raw"
 ANSIBLE_CORE_RAW_URL = "https://github.com/ansible/ansible/raw"

--- a/src/antsibull_build/constants.py
+++ b/src/antsibull_build/constants.py
@@ -33,7 +33,7 @@ ANSIBLE_DOCUMENTATION_MINIMUM = PypiVer("2.15.2")
 ANSIBLE_DOCUMENTATION_RANGES: dict[str, PypiVer] = {
     "2.13": PypiVer("2.13.11"),
     "2.14": PypiVer("2.14.8"),
-    # Temporarily use devel changelog for 2.19.0a1
+    # Temporarily use devel porting guide for 2.19.0a1
     # so https://github.com/ansible/ansible-documentation/pull/2429
     # gets included.
     "2.19": PypiVer("2.19.0a2"),


### PR DESCRIPTION
 Use devel porting guide for 2.19.0a1 so https://github.com/ansible/ansible-documentation/pull/2429 gets included.