### PR TITLE
Ensure there is whitespace between the preamble and the core porting guide

### DIFF
--- a/changelogs/fragments/663-pg.yml
+++ b/changelogs/fragments/663-pg.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Ensure that there is a newline between the preamble and ansible-core's porting guide content in the Ansible porting guide
+     (https://github.com/ansible-community/antsibull-build/issues/662, https://github.com/ansible-community/antsibull-build/pull/663)."

--- a/src/antsibull_build/build_changelog.py
+++ b/src/antsibull_build/build_changelog.py
@@ -781,6 +781,8 @@ class ReleaseNotes:
             if not found_empty:
                 flog.warning("Cannot find TOC of ansible-core porting guide!")
             if append_lines:
+                if append_lines[0]:
+                    append_lines.insert(0, "")
                 renderer.add_text(
                     "\n".join(append_lines), text_format=TextFormat.RESTRUCTURED_TEXT
                 )


### PR DESCRIPTION
Fixes #662.
