### PR TITLE
CI: remove extra session specifiers

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -32,19 +32,19 @@ jobs:
             codecov: true
             packages: ""
 
-          - session: "check_package_files-3.12(8.1.0)"
+          - session: "check_package_files(8.1.0)"
             python-versions: "3.12"
             force-python: "3.12"
             codecov: true
             packages: ""
 
-          - session: "check_package_files-3.11(7.5.0)"
+          - session: "check_package_files(7.5.0)"
             python-versions: "3.11"
             force-python: "3.11"
             codecov: true
             packages: ""
 
-          - session: "check_package_files-3.13(8.1.0_setup_cfg)"
+          - session: "check_package_files(8.1.0_setup_cfg)"
             python-versions: "3.13"
             force-python: "3.13"
             codecov: true

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           sudo apt-get install -y ${{ matrix.packages }}
       - name: Setup nox
-        uses: wntrblm/nox@2025.02.09
+        uses: wntrblm/nox@2025.05.01
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: Run nox


### PR DESCRIPTION
This should work once a new nox version is out, since https://github.com/wntrblm/nox/pull/958 has been merged.

I've added a TEMP commit that uses the `main` branch of nox.