### PR TITLE
build-release: fix broken boolean conditionals

### DIFF
--- a/changelogs/fragments/0.73.1.yml
+++ b/changelogs/fragments/0.73.1.yml
@@ -1,0 +1,1 @@
+release_summary: Bugfix release for build-release role and playbook

--- a/changelogs/fragments/668-ansible-bool.yml
+++ b/changelogs/fragments/668-ansible-bool.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - build-release role - fix broken conditionals by ensuring the `bool` filter
+  - build-release role - fix broken conditionals by ensuring the ``bool`` filter
     is always used
     (https://github.com/ansible-community/antsibull-build/pull/668).

--- a/changelogs/fragments/668-ansible-bool.yml
+++ b/changelogs/fragments/668-ansible-bool.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - build-release role - fix broken conditionals by ensuring the `bool` filter
+    is always used
+    (https://github.com/ansible-community/antsibull-build/pull/668).

--- a/roles/build-release/tasks/build.yaml
+++ b/roles/build-release/tasks/build.yaml
@@ -43,7 +43,7 @@
   ansible.builtin.set_fact:
     _feature_freeze: "--feature-frozen"
   when: 
-    - not antsibull_ignore_feature_freeze
+    - not (antsibull_ignore_feature_freeze | bool)
     - antsibull_ansible_version is regex("^\d+.\d+.\d+(b[2-9]|rc\d+)$")
 
 - name: Check whether the ansible deps file exists
@@ -66,17 +66,17 @@
   args:
     chdir: "{{ playbook_dir | dirname }}"
   when: >-
-    not antsibull_skip_prepare
+    not (antsibull_skip_prepare | bool)
     or not _antsibull_deps_file_stat.stat.exists
 
 - name: Find ignores file
-  when: antsibull_tags_validate
+  when: antsibull_tags_validate | bool
   register: _ignores_stat
   ansible.builtin.stat:
     dest: "{{ antsibull_tags_ignores_file }}"
 
 - name: Validate tags file
-  when: antsibull_tags_validate
+  when: antsibull_tags_validate | bool
   # ignore_errors creates conspicuous error messages without failing the playbook
   ignore_errors: "{{ not antsibull_tags_enforce_policy }}"
   # This command never changes anything


### PR DESCRIPTION
ansible-playbook allows passing variables with boolean values using `-e`, and the argspec validation passes, but then the variables are still set to string values which makes conditionals always evaluate to true.
Using the `bool` filter fixes this.