### PR TITLE
Allow ansible-core rcs when preparing a new beta release

### DIFF
--- a/changelogs/fragments/671-rc.yml
+++ b/changelogs/fragments/671-rc.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "When preparing a new Ansible beta release, also allow new release candidates of ansible-core (https://github.com/ansible-community/antsibull-build/pull/671)."

--- a/src/antsibull_build/build_ansible_commands.py
+++ b/src/antsibull_build/build_ansible_commands.py
@@ -339,6 +339,12 @@ def _is_alpha(version: PypiVer) -> bool:
     return version.is_prerelease and pre is not None and pre[0] == "a"
 
 
+def _is_alpha_or_beta(version: PypiVer) -> bool:
+    """Test whether the provided version is an alpha or beta version."""
+    pre = version.pre
+    return version.is_prerelease and pre is not None and pre[0] in ("a", "b")
+
+
 def _extract_python_requires(
     ansible_core_version: PypiVer, deps: dict[str, str]
 ) -> str:
@@ -381,6 +387,7 @@ def prepare_deps(
         list(ansible_core_release_infos),
         ansible_core_version_obj,
         pre=_is_alpha(ansible_version),
+        allow_rc=_is_alpha_or_beta(ansible_version),
     )
     if new_ansible_core_version:
         ansible_core_version_obj = new_ansible_core_version

--- a/src/antsibull_build/versions.py
+++ b/src/antsibull_build/versions.py
@@ -209,6 +209,7 @@ def get_latest_ansible_core_version(
     ansible_core_versions: Sequence[str],
     ansible_core_version: PypiVer,
     pre: bool = False,
+    allow_rc: bool = False,
 ) -> PypiVer | None:
     """
     Retrieve the latest ansible-core bugfix release's version for the given ansible-core version.
@@ -224,7 +225,10 @@ def get_latest_ansible_core_version(
         version
         for version in versions
         if ansible_core_version <= version < next_version
-        and (pre or not version.is_prerelease)
+        and (
+            (pre or not version.is_prerelease)
+            or (allow_rc and version.pre and version.pre[0] == "rc")
+        )
     ]
     return max(newer_versions) if newer_versions else None
 


### PR DESCRIPTION
Needed for Ansible 12.0.0b4, so it can include ansible-core 2.19.1rc1.