### PR TITLE
Add version regression check (enabled by default)

### DIFF
--- a/changelogs/fragments/673-version-regression.yml
+++ b/changelogs/fragments/673-version-regression.yml
@@ -1,2 +1,4 @@
 minor_changes:
   - "Add version regression check. It can be explicitly disabled if needed (https://github.com/ansible-community/antsibull-build/pull/673)."
+bugfixes:
+  - "build-release role - fix more broken conditionals by ensuring the ``bool`` filter is always used (https://github.com/ansible-community/antsibull-build/pull/673)."

--- a/changelogs/fragments/673-version-regression.yml
+++ b/changelogs/fragments/673-version-regression.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add version regression check. It can be explicitly disabled if needed (https://github.com/ansible-community/antsibull-build/pull/673)."

--- a/roles/build-release/defaults/main.yaml
+++ b/roles/build-release/defaults/main.yaml
@@ -51,6 +51,9 @@ antsibull_preserve_deps: false
 # Whether to ignore feature freeze
 antsibull_ignore_feature_freeze: false
 
+# Whether to ignore version regressions
+antsibull_ignore_version_regressions: false
+
 # Whether or not to start from scratch with a new venv if one exists
 antsibull_venv_cleanup: true
 

--- a/roles/build-release/meta/argument_specs.yml
+++ b/roles/build-release/meta/argument_specs.yml
@@ -161,3 +161,10 @@ argument_specs:
         type: bool
         default: false
         version_added: 0.73.0
+
+      antsibull_ignore_version_regressions:
+        description:
+          - If set to V(true), will not check for version regressions.
+        type: bool
+        default: false
+        version_added: 0.74.0

--- a/roles/build-release/tasks/build.yaml
+++ b/roles/build-release/tasks/build.yaml
@@ -56,9 +56,9 @@
     {{ antsibull_build_command }} prepare {{ antsibull_ansible_version }}
       --data-dir {{ antsibull_data_dir }}
       {{ _feature_freeze | default('') }}
-      {{ '--tags-file' if antsibull_tags_validate else '' }}
-      {{ '--preserve-deps' if antsibull_preserve_deps else '' }}
-      {{ '--ignore-version-regressions' if antsibull_ignore_version_regressions else '' }}
+      {{ '--tags-file' if (antsibull_tags_validate | bool) else '' }}
+      {{ '--preserve-deps' if (antsibull_preserve_deps | bool) else '' }}
+      {{ '--ignore-version-regressions' if (antsibull_ignore_version_regressions | bool) else '' }}
   # Minimal failure tolerance to galaxy collection download errors
   retries: 3
   delay: 5
@@ -105,7 +105,7 @@
       --build-file {{ antsibull_build_file }}
       --deps-file {{ _deps_file }}
       --debian
-      {{ '--tags-file' if antsibull_tags_validate else '' }}
+      {{ '--tags-file' if (antsibull_tags_validate | bool) else '' }}
   # Minimal failure tolerance to galaxy collection download errors
   retries: 3
   delay: 5

--- a/roles/build-release/tasks/build.yaml
+++ b/roles/build-release/tasks/build.yaml
@@ -58,6 +58,7 @@
       {{ _feature_freeze | default('') }}
       {{ '--tags-file' if antsibull_tags_validate else '' }}
       {{ '--preserve-deps' if antsibull_preserve_deps else '' }}
+      {{ '--ignore-version-regressions' if antsibull_ignore_version_regressions else '' }}
   # Minimal failure tolerance to galaxy collection download errors
   retries: 3
   delay: 5

--- a/src/antsibull_build/build_ansible_commands.py
+++ b/src/antsibull_build/build_ansible_commands.py
@@ -12,6 +12,7 @@ import os.path
 import shutil
 import sys
 import tempfile
+import typing as t
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -46,6 +47,7 @@ from .versions import (
     find_latest_compatible,
     get_latest_ansible_core_version,
     get_version_info,
+    load_all_dependency_files,
     load_constraints_if_exists,
 )
 
@@ -435,6 +437,57 @@ def validate_deps_data(
                 )
 
 
+def check_for_regressions(
+    ansible_version: PypiVer, deps: DependencyFileData, data_dir: os.PathLike[str] | str
+) -> None:
+    dependencies = {
+        PypiVer(deps_ansible_version): deps
+        for deps_ansible_version, deps in load_all_dependency_files(
+            data_dir,
+            accept_deps_file=lambda path, deps_ansible_version: PypiVer(
+                deps_ansible_version
+            )
+            < ansible_version,
+        ).items()
+    }
+    if not dependencies:
+        return
+    previous_release = max(dependencies)
+    previous_release_deps = dependencies[previous_release]
+
+    _VT = t.TypeVar("_VT", SemVer, PypiVer)
+
+    def _check_for_regression(
+        what: str,
+        new_version: str,
+        old_version: str,
+        version_constructor: t.Callable[[str], _VT],
+    ) -> None:
+        new_ver = version_constructor(new_version)
+        old_ver = version_constructor(old_version)
+        if old_ver > new_ver:
+            raise ValueError(
+                f"The old version ({old_version}) of {what}"
+                f" included in Ansible {previous_release} is newer"
+                f" than the new version ({new_version})"
+                f" that would be included in Ansible {ansible_version}!"
+            )
+
+    _check_for_regression(
+        "ansible-core",
+        deps.ansible_core_version,
+        previous_release_deps.ansible_core_version,
+        PypiVer,
+    )
+    for collection_name, collection_version in deps.deps.items():
+        previous_version = previous_release_deps.deps.get(collection_name)
+        if previous_version is None:
+            continue
+        _check_for_regression(
+            collection_name, collection_version, previous_version, SemVer
+        )
+
+
 def prepare_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
@@ -444,13 +497,14 @@ def prepare_command() -> int:
     build_file = BuildFile(build_filename)
     build_ansible_version, ansible_core_version, build_deps = build_file.parse()
     ansible_core_version_obj = PypiVer(ansible_core_version)
+    ansible_version: PypiVer = app_ctx.extra["ansible_version"]
     python_requires = _extract_python_requires(ansible_core_version_obj, build_deps)
+    ignore_version_regressions: bool = app_ctx.extra["ignore_version_regressions"]
 
     if not str(app_ctx.extra["ansible_version"]).startswith(build_ansible_version):
         print(
             f"{build_filename} is for version {build_ansible_version} but we need"
-            f' {app_ctx.extra["ansible_version"].major}'
-            f'.{app_ctx.extra["ansible_version"].minor}',
+            f" {ansible_version.major}.{ansible_version.minor}",
             file=sys.stderr,
         )
         return 1
@@ -478,7 +532,7 @@ def prepare_command() -> int:
         python_requires = dependency_data.deps.pop("_python")
     else:
         dependency_data = prepare_deps(
-            app_ctx.extra["ansible_version"],
+            ansible_version,
             ansible_core_version_obj,
             build_deps,
             constraints,
@@ -494,13 +548,25 @@ def prepare_command() -> int:
         )
         return 1
 
-    # Get Ansible changelog, add new release
+    if not ignore_version_regressions:
+        try:
+            check_for_regressions(
+                ansible_version, dependency_data, app_ctx.extra["data_dir"]
+            )
+        except ValueError as exc:
+            print(
+                f"Error while checking for version regressions: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+    # Get Ansible changelog and add new release
     ansible_changelog = ChangelogData.ansible(
         app_ctx.extra["data_dir"], app_ctx.extra["dest_data_dir"]
     )
     date = datetime.date.today()
     ansible_changelog.add_ansible_release(
-        str(app_ctx.extra["ansible_version"]),
+        str(ansible_version),
         date,
         f"Release Date: {date}"
         f"\n\n"

--- a/src/antsibull_build/build_ansible_commands.py
+++ b/src/antsibull_build/build_ansible_commands.py
@@ -444,10 +444,9 @@ def check_for_regressions(
         PypiVer(deps_ansible_version): deps
         for deps_ansible_version, deps in load_all_dependency_files(
             data_dir,
-            accept_deps_file=lambda path, deps_ansible_version: PypiVer(
-                deps_ansible_version
-            )
-            < ansible_version,
+            accept_deps_file=lambda path, deps_ansible_version: (
+                PypiVer(deps_ansible_version) < ansible_version
+            ),
         ).items()
     }
     if not dependencies:
@@ -467,9 +466,9 @@ def check_for_regressions(
         old_ver = version_constructor(old_version)
         if old_ver > new_ver:
             raise ValueError(
-                f"The old version ({old_version}) of {what}"
+                f"The previous version ({old_version}) of {what}"
                 f" included in Ansible {previous_release} is newer"
-                f" than the new version ({new_version})"
+                f" than the version ({new_version})"
                 f" that would be included in Ansible {ansible_version}!"
             )
 

--- a/src/antsibull_build/cli/antsibull_build.py
+++ b/src/antsibull_build/cli/antsibull_build.py
@@ -468,7 +468,7 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         "--allow-prereleases",
         action="store_true",
         default=False,
-        help="Allow prereleases of collections to be included in the build" " file",
+        help="Allow prereleases of collections to be included in the build file",
     )
     new_parser.add_argument(
         "--constraints-file",
@@ -499,6 +499,13 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         f" as {DEFAULT_FILE_BASE}-X.Y.Z-tags.yaml."
         " --tags-file takes an optional argument to change the filename.",
     )
+    prepare_parser.add_argument(
+        "--ignore-version-regressions",
+        action="store_true",
+        default=False,
+        help="Allow versions of ansible-core or collections to regress"
+        " with respect to the previous Ansible release",
+    )
 
     build_single_parser = subparsers.add_parser(
         "single",
@@ -510,7 +517,7 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
             galaxy_file_parser,
             preserve_deps_parser,
         ],
-        description="Build a single-file Ansible" " [deprecated]",
+        description="Build a single-file Ansible [deprecated]",
     )
     build_single_parser.add_argument(
         "--sdist-dir",
@@ -560,7 +567,7 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
             build_step_parser,
             package_file_parser,
         ],
-        description="Rebuild a single-file Ansible from" " a dependency file",
+        description="Rebuild a single-file Ansible from a dependency file",
     )
     rebuild_single_parser.add_argument(
         "--sdist-dir",

--- a/src/antsibull_build/versions.py
+++ b/src/antsibull_build/versions.py
@@ -346,8 +346,17 @@ def load_all_dependency_files(
     *,
     accept_deps_file: t.Callable[[os.PathLike[str] | str, str], bool] | None = None,
 ) -> dict[str, DependencyFileData]:
+    """
+    Find and load all ``.deps`` files in ``deps_dir`` and return a mapping of Ansible
+    versions to parsed dependency file data.
+
+    ``accept_deps_file`` allows to provide a filter callback that is called for every
+    ``.deps`` file. The first argument is the filename, and the second the Ansible
+    version of the ``.deps`` file. The ``.deps`` file is added to the result if the
+    callback returns ``True``.
+    """
     dependencies: dict[str, DependencyFileData] = {}
-    for path in glob.glob(os.path.join(deps_dir, "*.deps"), recursive=False):
+    for path in glob.iglob(os.path.join(deps_dir, "*.deps"), recursive=False):
         deps_file = DepsFile(path)
         deps = deps_file.parse()
         deps.deps.pop("_python", None)


### PR DESCRIPTION
As described on Matrix.

Example error after first preparing `12.0.0b4` and then `12.0.0rc1`:
```
Error while checking for version regressions: The old version (2.19.1rc1) of ansible-core included in Ansible 12.0.0b4 is newer than the new version (2.19.0) that would be included in Ansible 12.0.0rc1!
```
Re-running that command with `--ignore-version-regressions` produces a `.deps` file with `_ansible_core_version: 2.19.0` for 12.0.0rc1 (12.0.0b4 has `_ansible_core_version: 2.19.1rc1`).