### PR TITLE
Refactor release role and playbooks

### DIFF
--- a/playbooks/build-single-release.yaml
+++ b/playbooks/build-single-release.yaml
@@ -5,7 +5,7 @@
 
 - name: Build a single Ansible release
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Include build-release role
       ansible.builtin.include_role:

--- a/playbooks/nested-ansible-tests.yaml
+++ b/playbooks/nested-ansible-tests.yaml
@@ -6,12 +6,12 @@
 # These tests are meant to be run by another Ansible (i.e, the one built with build-single-release.yaml)
 - name: Run nested Ansible tests
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   vars:
     # These can be supplied as extra-vars but are expected to come from roles/build-release/tasks/tests.yaml
     antsibull_sdist_dir: "{{ playbook_dir | dirname }}/build"
     antsibull_ansible_venv: "{{ antsibull_sdist_dir }}/venv"
-    _python_version: "python3.9"
+    _python_version: "python3.13"
   tasks:
     - name: Parse installed ansible_builtin_runtime
       parse_ansible_runtime:

--- a/roles/build-release/tasks/tests.yaml
+++ b/roles/build-release/tasks/tests.yaml
@@ -24,92 +24,98 @@
     virtualenv: "{{ antsibull_ansible_venv }}"
     virtualenv_command: "{{ ansible_python.executable }} -m venv"
 
-# Note: the version of ansible-core doesn't necessarily match the deps file since the version requirement is >=
-- block:
-    - name: Load deps_file
-      ansible.builtin.set_fact:
-        _deps: >-
-          {{ lookup('file', antsibull_data_dir ~ '/' ~ _deps_file) | _antsibull_parse_deps }}
+- vars:
+    antsibull_venv_pip_bin: "{{ antsibull_ansible_venv }}/bin/pip"
+    antsibull_venv_pip_pkgs: "{{ _pip_pkgs['packages'][antsibull_venv_pip_bin] }}"
+    antsibull_venv_pip_ansible_version: "{{ antsibull_venv_pip_pkgs['ansible'][0]['version'] }}"
+    antsibull_venv_pip_ansible_core_version: "{{ antsibull_venv_pip_pkgs['ansible-core'][0]['version'] }}"
+  block:
+    # Note: the version of ansible-core doesn't necessarily match the deps file since the version requirement is >=
+    - block:
+        - name: Load deps_file
+          ansible.builtin.set_fact:
+            _deps: >-
+              {{ lookup('file', antsibull_data_dir ~ '/' ~ _deps_file) | _antsibull_parse_deps }}
 
-    - name: Query installed pip packages
-      community.general.pip_package_info:
-        clients: "{{ antsibull_venv_pip_bin }}"
-      register: _pip_pkgs
+        - name: Query installed pip packages
+          community.general.pip_package_info:
+            clients: "{{ antsibull_venv_pip_bin }}"
+          register: _pip_pkgs
 
-    - name: Validate the version of ansible-core
-      ansible.builtin.assert:
-        that:
-          - antsibull_venv_pip_ansible_core_version is _antsibull_packaging_version(antsibull_expected_ansible_core, '>=')
-        success_msg: "ansible-core {{ antsibull_venv_pip_ansible_core_version }} matches (or exceeds) {{ _deps_file }}"
-        fail_msg: "ansible-core {{ antsibull_venv_pip_ansible_core_version }} does not match {{ _deps_file }}"
-      vars:
-        antsibull_expected_ansible_core: "{{ _deps['_ansible_core_version'] }}"
+        - name: Validate the version of ansible-core
+          ansible.builtin.assert:
+            that:
+              - antsibull_venv_pip_ansible_core_version is _antsibull_packaging_version(antsibull_expected_ansible_core, '>=')
+            success_msg: "ansible-core {{ antsibull_venv_pip_ansible_core_version }} matches (or exceeds) {{ _deps_file }}"
+            fail_msg: "ansible-core {{ antsibull_venv_pip_ansible_core_version }} does not match {{ _deps_file }}"
+          vars:
+            antsibull_expected_ansible_core: "{{ _deps['_ansible_core_version'] }}"
 
-- block:
-    - name: Retrieve collections that should be included in the package
-      shell: cat {{ antsibull_data_dir }}/ansible.in | grep -vE "^#"
-      changed_when: false
-      register: _included_collections
+    - block:
+        - name: Retrieve collections that should be included in the package
+          shell: cat {{ antsibull_data_dir }}/ansible.in | grep -vE "^#"
+          changed_when: false
+          register: _included_collections
 
-    - name: Retrieve the builtin reported version of ansible
-      ansible.builtin.command: >-
-        {{ antsibull_ansible_venv }}/bin/python3 -c 'from ansible_collections.ansible_release import ansible_version; print(ansible_version)'
-      changed_when: false
-      register: _ansible_version_builtin
-
-    - name: Validate the version of ansible
-      ansible.builtin.assert:
-        that:
-          - antsibull_venv_pip_ansible_version == _deps['_ansible_version']
-          - antsibull_venv_pip_ansible_version == _ansible_version_builtin.stdout
-        success_msg: "ansible {{ antsibull_venv_pip_ansible_version }} matches {{ _deps_file }} as well as 'ansible_collections.ansible_release'"
-        fail_msg: "ansible {{ antsibull_venv_pip_ansible_version }} does not match {{ _deps_file }} or 'ansible_collections.ansible_release'"
-
-    - when: antsibull_ansible_version is _antsibull_packaging_version('6.0.0rc1', '>=')
-      block:
-        - name: Retrieve the builtin reported version of ansible from the ansible-community CLI tool
+        - name: Retrieve the builtin reported version of ansible
           ansible.builtin.command: >-
-            {{ antsibull_ansible_venv }}/bin/ansible-community --version
+            {{ antsibull_ansible_venv }}/bin/python3 -c 'from ansible_collections.ansible_release import ansible_version; print(ansible_version)'
           changed_when: false
-          register: _ansible_version_builtin_2
+          register: _ansible_version_builtin
 
-        - name: Verify that the version output matches the one we expect
+        - name: Validate the version of ansible
           ansible.builtin.assert:
             that:
-              - _ansible_version_builtin_2.stdout == ("Ansible community version " ~ antsibull_ansible_version)
+              - antsibull_venv_pip_ansible_version == _deps['_ansible_version']
+              - antsibull_venv_pip_ansible_version == _ansible_version_builtin.stdout
+            success_msg: "ansible {{ antsibull_venv_pip_ansible_version }} matches {{ _deps_file }} as well as 'ansible_collections.ansible_release'"
+            fail_msg: "ansible {{ antsibull_venv_pip_ansible_version }} does not match {{ _deps_file }} or 'ansible_collections.ansible_release'"
 
-    - vars:
-        antsibull_collections_path: "{{ antsibull_ansible_venv }}/lib/{{ _python_version }}/site-packages/ansible_collections"
-        _antsibull_installed_collections: "{{ _installed_collections_json['stdout'] | from_json }}"
-        antsibull_installed_collections: "{{ _antsibull_installed_collections[antsibull_collections_path] }}"
-      block:
-        - name: Retrieve installed collections
-          environment:
-            # In case we happen to be testing with devel, don't print a warning about it
-            ANSIBLE_DEVEL_WARNING: false
-            # Until https://github.com/ansible/ansible/pull/70173 is backported and released
-            ANSIBLE_COLLECTIONS_PATH: "{{ antsibull_collections_path }}"
-          # List collections, remove empty lines, headers, file paths and format the results in the same way as the deps file
-          ansible.builtin.command:
-            cmd: "{{ antsibull_ansible_venv }}/bin/ansible-galaxy collection list --format json"
-          changed_when: false
-          register: _installed_collections_json
+        - when: antsibull_ansible_version is _antsibull_packaging_version('6.0.0rc1', '>=')
+          block:
+            - name: Retrieve the builtin reported version of ansible from the ansible-community CLI tool
+              ansible.builtin.command: >-
+                {{ antsibull_ansible_venv }}/bin/ansible-community --version
+              changed_when: false
+              register: _ansible_version_builtin_2
 
-        - name: Validate that the installed collections are the expected ones
-          ansible.builtin.assert:
-            that:
-              - item['value']['version'] == _deps[item['key']]
-            success_msg: "{{ item }} matches {{ _deps_file }}"
-            fail_msg: "{{ item }} does not match {{ _deps_file }}"
-          loop: "{{ antsibull_installed_collections | dict2items }}"
+            - name: Verify that the version output matches the one we expect
+              ansible.builtin.assert:
+                that:
+                  - _ansible_version_builtin_2.stdout == ("Ansible community version " ~ antsibull_ansible_version)
 
-        - name: Validate that included collections are packaged
-          ansible.builtin.assert:
-            that:
-              - item in antsibull_installed_collections
-            success_msg: "{{ item }} is in ansible.in and inside the package"
-            fail_msg: "{{ item }} is in ansible.in but not inside the package. Maybe run 'antsibull-build new-ansible --data-dir={{ antsibull_data_dir }}' to update ansible.in and then rebuild ?"
-          loop: "{{ _included_collections.stdout_lines }}"
+        - vars:
+            antsibull_collections_path: "{{ antsibull_ansible_venv }}/lib/{{ _python_version }}/site-packages/ansible_collections"
+            _antsibull_installed_collections: "{{ _installed_collections_json['stdout'] | from_json }}"
+            antsibull_installed_collections: "{{ _antsibull_installed_collections[antsibull_collections_path] }}"
+          block:
+            - name: Retrieve installed collections
+              environment:
+                # In case we happen to be testing with devel, don't print a warning about it
+                ANSIBLE_DEVEL_WARNING: false
+                # Until https://github.com/ansible/ansible/pull/70173 is backported and released
+                ANSIBLE_COLLECTIONS_PATH: "{{ antsibull_collections_path }}"
+              # List collections, remove empty lines, headers, file paths and format the results in the same way as the deps file
+              ansible.builtin.command:
+                cmd: "{{ antsibull_ansible_venv }}/bin/ansible-galaxy collection list --format json"
+              changed_when: false
+              register: _installed_collections_json
+
+            - name: Validate that the installed collections are the expected ones
+              ansible.builtin.assert:
+                that:
+                  - item['value']['version'] == _deps[item['key']]
+                success_msg: "{{ item }} matches {{ _deps_file }}"
+                fail_msg: "{{ item }} does not match {{ _deps_file }}"
+              loop: "{{ antsibull_installed_collections | dict2items }}"
+
+            - name: Validate that included collections are packaged
+              ansible.builtin.assert:
+                that:
+                  - item in antsibull_installed_collections
+                success_msg: "{{ item }} is in ansible.in and inside the package"
+                fail_msg: "{{ item }} is in ansible.in but not inside the package. Maybe run 'antsibull-build new-ansible --data-dir={{ antsibull_data_dir }}' to update ansible.in and then rebuild ?"
+              loop: "{{ _included_collections.stdout_lines }}"
 
 - name: Run nested tests
   vars:

--- a/roles/build-release/tasks/tests.yaml
+++ b/roles/build-release/tasks/tests.yaml
@@ -118,20 +118,7 @@
               loop: "{{ _included_collections.stdout_lines }}"
 
 - name: Run nested tests
-  vars:
-    ansible_collections_path: "{{ antsibull_sdist_dir }}/ansible_collections"
-  environment:
-    ANSIBLE_COLLECTIONS_PATH: "{{ ansible_collections_path }}"
   block:
-    - name: Create a temporary COLLECTIONS_PATH
-      ansible.builtin.file:
-        path: "{{ ansible_collections_path }}"
-        state: directory
-
-    - name: Install community.general for tests using 'a_module' and 'collection_version'
-      ansible.builtin.command: >-
-        {{ antsibull_ansible_venv }}/bin/ansible-galaxy collection install community.general
-
     - name: Run nested Ansible tests with the Ansible we just built
       ansible.builtin.command: >-
         {{ antsibull_ansible_venv }}/bin/ansible-playbook -i 'localhost,' --connection=local

--- a/roles/build-release/tasks/tests.yaml
+++ b/roles/build-release/tasks/tests.yaml
@@ -42,6 +42,8 @@
           - antsibull_venv_pip_ansible_core_version is _antsibull_packaging_version(antsibull_expected_ansible_core, '>=')
         success_msg: "ansible-core {{ antsibull_venv_pip_ansible_core_version }} matches (or exceeds) {{ _deps_file }}"
         fail_msg: "ansible-core {{ antsibull_venv_pip_ansible_core_version }} does not match {{ _deps_file }}"
+      vars:
+        antsibull_expected_ansible_core: "{{ _deps['_ansible_core_version'] }}"
 
 - block:
     - name: Retrieve collections that should be included in the package
@@ -76,33 +78,38 @@
             that:
               - _ansible_version_builtin_2.stdout == ("Ansible community version " ~ antsibull_ansible_version)
 
-    - name: Retrieve installed collections
-      environment:
-        # In case we happen to be testing with devel, don't print a warning about it
-        ANSIBLE_DEVEL_WARNING: false
-        # Until https://github.com/ansible/ansible/pull/70173 is backported and released
-        ANSIBLE_COLLECTIONS_PATH: "{{ antsibull_collections_path }}"
-      # List collections, remove empty lines, headers, file paths and format the results in the same way as the deps file
-      ansible.builtin.command:
-        cmd: "{{ antsibull_ansible_venv }}/bin/ansible-galaxy collection list --format json"
-      changed_when: false
-      register: _installed_collections_json
+    - vars:
+        antsibull_collections_path: "{{ antsibull_ansible_venv }}/lib/{{ _python_version }}/site-packages/ansible_collections"
+        _antsibull_installed_collections: "{{ _installed_collections_json['stdout'] | from_json }}"
+        antsibull_installed_collections: "{{ _antsibull_installed_collections[antsibull_collections_path] }}"
+      block:
+        - name: Retrieve installed collections
+          environment:
+            # In case we happen to be testing with devel, don't print a warning about it
+            ANSIBLE_DEVEL_WARNING: false
+            # Until https://github.com/ansible/ansible/pull/70173 is backported and released
+            ANSIBLE_COLLECTIONS_PATH: "{{ antsibull_collections_path }}"
+          # List collections, remove empty lines, headers, file paths and format the results in the same way as the deps file
+          ansible.builtin.command:
+            cmd: "{{ antsibull_ansible_venv }}/bin/ansible-galaxy collection list --format json"
+          changed_when: false
+          register: _installed_collections_json
 
-    - name: Validate that the installed collections are the expected ones
-      ansible.builtin.assert:
-        that:
-          - item['value']['version'] == _deps[item['key']]
-        success_msg: "{{ item }} matches {{ _deps_file }}"
-        fail_msg: "{{ item }} does not match {{ _deps_file }}"
-      loop: "{{ antsibull_installed_collections | dict2items }}"
+        - name: Validate that the installed collections are the expected ones
+          ansible.builtin.assert:
+            that:
+              - item['value']['version'] == _deps[item['key']]
+            success_msg: "{{ item }} matches {{ _deps_file }}"
+            fail_msg: "{{ item }} does not match {{ _deps_file }}"
+          loop: "{{ antsibull_installed_collections | dict2items }}"
 
-    - name: Validate that included collections are packaged
-      ansible.builtin.assert:
-        that:
-          - item in antsibull_installed_collections
-        success_msg: "{{ item }} is in ansible.in and inside the package"
-        fail_msg: "{{ item }} is in ansible.in but not inside the package. Maybe run 'antsibull-build new-ansible --data-dir={{ antsibull_data_dir }}' to update ansible.in and then rebuild ?"
-      loop: "{{ _included_collections.stdout_lines }}"
+        - name: Validate that included collections are packaged
+          ansible.builtin.assert:
+            that:
+              - item in antsibull_installed_collections
+            success_msg: "{{ item }} is in ansible.in and inside the package"
+            fail_msg: "{{ item }} is in ansible.in but not inside the package. Maybe run 'antsibull-build new-ansible --data-dir={{ antsibull_data_dir }}' to update ansible.in and then rebuild ?"
+          loop: "{{ _included_collections.stdout_lines }}"
 
 - name: Run nested tests
   vars:

--- a/roles/build-release/vars/main.yml
+++ b/roles/build-release/vars/main.yml
@@ -3,15 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Note: the value is either _ansible_base_version or _ansible_core_version depending on the version
-# ex: https://github.com/ansible-community/ansible-build-data/blob/main/4/ansible-4.4.0.deps
-# Variables that start with `_` are intermediate variables that are `register`ed in the playbook.
-antsibull_expected_ansible_core: "{{ _deps['_ansible_core_version'] | default(_deps['_ansible_base_version']) }}"
 antsibull_venv_pip_bin: "{{ antsibull_ansible_venv }}/bin/pip"
 antsibull_venv_pip_pkgs: "{{ _pip_pkgs['packages'][antsibull_venv_pip_bin] }}"
 antsibull_venv_pip_ansible_version: "{{ antsibull_venv_pip_pkgs['ansible'][0]['version'] }}"
 antsibull_venv_pip_ansible_core_version: "{{ antsibull_venv_pip_pkgs['ansible-core'][0]['version'] }}"
-
-antsibull_collections_path: "{{ antsibull_ansible_venv }}/lib/{{ _python_version }}/site-packages/ansible_collections"
-_antsibull_installed_collections: "{{ _installed_collections_json['stdout'] | from_json }}"
-antsibull_installed_collections: "{{ _antsibull_installed_collections[antsibull_collections_path] }}"

--- a/roles/build-release/vars/main.yml
+++ b/roles/build-release/vars/main.yml
@@ -2,8 +2,3 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-antsibull_venv_pip_bin: "{{ antsibull_ansible_venv }}/bin/pip"
-antsibull_venv_pip_pkgs: "{{ _pip_pkgs['packages'][antsibull_venv_pip_bin] }}"
-antsibull_venv_pip_ansible_version: "{{ antsibull_venv_pip_pkgs['ansible'][0]['version'] }}"
-antsibull_venv_pip_ansible_core_version: "{{ antsibull_venv_pip_pkgs['ansible-core'][0]['version'] }}"


### PR DESCRIPTION
Right now some variables (more like: local functions, since they process data produced by earlier tasks) are defined in vars/main.yml, but only used quite locally. I think it's better to declare them locally with `vars:` so it is easier to understand what is going on.