### PR TITLE
verify_package_files: assign to correct member

### DIFF
--- a/tests/verify_package_files.py
+++ b/tests/verify_package_files.py
@@ -84,7 +84,7 @@ class AnsibleSdist:
             for member in file.getmembers():
                 if not member.name.startswith(collections_dir):
                     continue
-                member.path = member.name[len(self.nv) + 1 :]
+                member.name = member.name[len(self.nv) + 1 :]
                 members.append(member)
             file.extractall(extract_dir, members, filter="data")
 


### PR DESCRIPTION
The typing tests exposed a bug: https://github.com/ansible-community/antsibull-build/actions/runs/17721931535/job/50355823756

Let's see whether this is the right fix.