### PR TITLE
Allow to make edits in releases

### DIFF
--- a/src/antsibull_build/build_ansible_commands.py
+++ b/src/antsibull_build/build_ansible_commands.py
@@ -40,6 +40,7 @@ from .ansible_core_reqs import check_collection_ansible_core_requirements
 from .build_changelog import ReleaseNotes
 from .changelog import ChangelogData, get_changelog
 from .dep_closure import check_collection_dependencies
+from .schemas.release_edits import PathInfo, ReleaseEdits, load_edit_file
 from .tagging import get_collections_tags
 from .utils.galaxy import create_galaxy_context
 from .utils.get_pkg_data import get_antsibull_data
@@ -596,6 +597,35 @@ def prepare_command() -> int:
     return 0
 
 
+def apply_edit(path: str, info: PathInfo) -> None:
+    if info.delete:
+        if info.delete.recursive:
+            print(f"Deleting {path} recursively...")
+            if not os.path.isdir(path) or os.path.islink(path):
+                raise ValueError(f"Error: {path} is not a directory")
+            shutil.rmtree(path)
+        else:
+            print(f"Deleting {path}...")
+            os.unlink(path)
+
+
+def apply_edit_data(edit_data: ReleaseEdits, package_dir: str) -> None:
+    package_dir = os.path.abspath(package_dir)
+    for path, info in sorted(edit_data.paths.items()):
+        full_path = os.path.join(package_dir, path)
+
+        # Sanity checks so that path doesn't point outside of package_dir
+        directory, basename = os.path.split(full_path)
+        if basename in (".", ".."):
+            raise ValueError(f"Invalid edit path {path!r}")
+        absdir = os.path.abspath(directory)
+        if absdir != package_dir and not absdir.startswith(f"{package_dir}{os.sep}"):
+            raise ValueError(f"Invalid edit path {path!r}")
+
+        # Apply edits
+        apply_edit(full_path, info)
+
+
 def rebuild_single_command() -> int:
     app_ctx = app_context.app_ctx.get()
     lib_ctx = app_context.lib_ctx.get()
@@ -610,6 +640,10 @@ def rebuild_single_command() -> int:
         )
     except ValueError:
         python_requires = None
+
+    # Load edits
+    edit_filename = deps_filename.replace(".deps", "-edit.yaml")
+    edit_data = load_edit_file(edit_filename)
 
     # Determine included collection versions
     ansible_core_version = PypiVer(dependency_data.ansible_core_version)
@@ -673,6 +707,9 @@ def rebuild_single_command() -> int:
         ]
 
         asyncio.run(install_together(collections_to_install, ansible_collections_dir))
+
+        # Apply edits
+        apply_edit_data(edit_data, package_dir)
 
         # Compose and write release notes to destination directory
         release_notes = ReleaseNotes.build(changelog)

--- a/src/antsibull_build/build_ansible_commands.py
+++ b/src/antsibull_build/build_ansible_commands.py
@@ -610,7 +610,7 @@ def apply_edit(path: str, info: PathInfo) -> None:
 
 
 def apply_edit_data(edit_data: ReleaseEdits, package_dir: str) -> None:
-    package_dir = os.path.abspath(package_dir)
+    package_dir = os.path.realpath(package_dir)
     for path, info in sorted(edit_data.paths.items()):
         full_path = os.path.join(package_dir, path)
 
@@ -618,7 +618,7 @@ def apply_edit_data(edit_data: ReleaseEdits, package_dir: str) -> None:
         directory, basename = os.path.split(full_path)
         if basename in (".", ".."):
             raise ValueError(f"Invalid edit path {path!r}")
-        absdir = os.path.abspath(directory)
+        absdir = os.path.realpath(directory)
         if absdir != package_dir and not absdir.startswith(f"{package_dir}{os.sep}"):
             raise ValueError(f"Invalid edit path {path!r}")
 

--- a/src/antsibull_build/build_data_lint.py
+++ b/src/antsibull_build/build_data_lint.py
@@ -10,6 +10,7 @@ Code to lint build data.
 
 from __future__ import annotations
 
+import glob
 import os
 
 import pydantic as p
@@ -21,6 +22,7 @@ from antsibull_core.pydantic import get_formatted_error_messages
 from semantic_version import Version as SemVer
 
 from .changelog import RemoveCollectionChangelogEntries
+from .schemas.release_edits import lint_edit_file
 
 
 def _lint_rcce(rcce: dict, errors: list[str]) -> None:
@@ -76,6 +78,14 @@ def lint_build_data() -> int:
         preprocess_data=lambda data: _lint_changelog_extra_data(data, errors),
     ):
         errors.append(f"{path}: {message}")
+
+    # Lint release edits
+    for edit in glob.glob(os.path.join(data_dir, "*-edit.yaml")):
+        deps_file = edit.replace("-edit.yaml", ".deps")
+        if not os.path.isfile(deps_file):
+            errors.append(f"{edit}: no associated deps file {deps_file} found")
+        for message in lint_edit_file(edit):
+            errors.append(f"{edit}: {message}")
 
     # Show results
     for message in sorted(errors):

--- a/src/antsibull_build/schemas/release_edits.py
+++ b/src/antsibull_build/schemas/release_edits.py
@@ -1,0 +1,78 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Ansible Project, 2026
+
+"""
+Classes to encapsulate release edit data from ansible-X.Y.Z-edit.yaml
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import pydantic as p
+from antsibull_core.pydantic import get_formatted_error_messages
+from antsibull_fileutils.yaml import load_yaml_file
+
+if t.TYPE_CHECKING:
+    from _typeshed import StrPath
+
+
+class DeleteInfo(p.BaseModel):
+    """
+    Information on deletions.
+    """
+
+    recursive: bool = False
+
+
+class PathInfo(p.BaseModel):
+    """
+    Stores edits for a path.
+    """
+
+    delete: t.Optional[DeleteInfo] = None
+
+    @p.model_validator(mode="after")
+    def _check_exactly_one(self) -> t.Self:
+        fields = [self.delete]
+        not_none = sum(f is not None for f in fields if f is not None)
+        if not_none != 1:
+            raise ValueError("exactly one field must be present")
+        return self
+
+
+class ReleaseEdits(p.BaseModel):
+    """
+    Release edits.
+    """
+
+    paths: dict[str, PathInfo] = {}
+
+
+def load_edit_file(file: StrPath) -> ReleaseEdits:
+    """
+    Lint release edits file.
+    """
+    try:
+        data = load_yaml_file(file)
+    except FileNotFoundError:
+        return ReleaseEdits()
+    return ReleaseEdits.model_validate(data)
+
+
+def lint_edit_file(file: StrPath) -> list[str]:
+    """
+    Lint release edits file.
+    """
+    try:
+        data = load_yaml_file(file)
+    except Exception as exc:
+        return [f"Error while parsing file: {exc}"]
+    try:
+        ReleaseEdits.model_validate(data, extra="forbid")
+        return []
+    except p.ValidationError as e:
+        return get_formatted_error_messages(e)


### PR DESCRIPTION
For now, only allow deletions, to fix things like https://github.com/ansible-community/ansible-build-data/issues/720.

For that issue, an `ansible-14.3.1-edit.yaml` with content:
```yaml
---
paths:
  ansible_collections/infinidat/infinibox/infinidat:
    delete:
      recursive: true
```
should do the trick.